### PR TITLE
Upgraded das-server-scala to 0.1.7

### DIFF
--- a/das-jira-connector/pom.xml
+++ b/das-jira-connector/pom.xml
@@ -123,7 +123,7 @@
 
         <!-- RAW Labs Dependencies -->
         <das-java-sdk-version>0.1.3</das-java-sdk-version>
-        <das-server-scala-version>0.1.6</das-server-scala-version>
+        <das-server-scala-version>0.1.7</das-server-scala-version>
         <jira-rest-client-version>1.0-SNAPSHOT</jira-rest-client-version>
         <protocol-das.version>0.1.4</protocol-das.version>
 


### PR DESCRIPTION
This enables the caching of SDKs, reused if the same config is re-registered.

I tested the change by requesting the same DAS config in a loop and using the schema from Postgres.