### PR TITLE
Fixed RD-15230: 'summary' and 'description' returned as NULL

### DIFF
--- a/das-jira-connector/src/main/java/com/rawlabs/das/jira/tables/definitions/DASJiraBacklogIssueTable.java
+++ b/das-jira-connector/src/main/java/com/rawlabs/das/jira/tables/definitions/DASJiraBacklogIssueTable.java
@@ -218,8 +218,7 @@ public class DASJiraBacklogIssueTable extends DASJiraIssueTransformationTable {
             "Display name of the user/application that created the issue.",
             createStringType()));
     columnDefinitions.put(
-        "description",
-        createColumn("description", "Description of the issue.", createStringType()));
+        "description", createColumn("description", "Description of the issue.", createAnyType()));
     columnDefinitions.put(
         "due_date",
         createColumn(

--- a/das-jira-connector/src/main/java/com/rawlabs/das/jira/tables/definitions/DASJiraIssueTable.java
+++ b/das-jira-connector/src/main/java/com/rawlabs/das/jira/tables/definitions/DASJiraIssueTable.java
@@ -257,7 +257,7 @@ public class DASJiraIssueTable extends DASJiraIssueTransformationTable {
             "Time by which the issue is expected to be completed",
             createTimestampType()));
     columns.put(
-        "description", createColumn("description", "Description of the issue", createStringType()));
+        "description", createColumn("description", "Description of the issue", createAnyType()));
     columns.put("type", createColumn("type", "The name of the issue type", createStringType()));
     columns.put(
         "labels",

--- a/das-jira-connector/src/test/java/com/rawlabs/das/jira/tables/defnitions/DASJiraIssueTableTest.java
+++ b/das-jira-connector/src/test/java/com/rawlabs/das/jira/tables/defnitions/DASJiraIssueTableTest.java
@@ -1,6 +1,7 @@
 package com.rawlabs.das.jira.tables.defnitions;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.rawlabs.das.jira.rest.platform.ApiException;
 import com.rawlabs.das.jira.rest.platform.api.IssueSearchApi;
 import com.rawlabs.das.jira.rest.platform.model.SearchResults;
@@ -13,6 +14,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -59,6 +61,14 @@ public class DASJiraIssueTableTest extends BaseMockTest {
       assertEquals("33060", extractValueFactory.extractValue(row, "id"));
       assertEquals("SP-1", extractValueFactory.extractValue(row, "key"));
       assertEquals("Task", extractValueFactory.extractValue(row, "type"));
+      assertEquals("test issue", extractValueFactory.extractValue(row, "summary"));
+      ObjectNode description = (ObjectNode) extractValueFactory.extractValue(row, "description");
+      // Fetch the first text of the content ("do this")
+      assertEquals(
+          "do this", description.get("content").get(0).get("content").get(0).get("text").asText());
+      ArrayList<String> components =
+          (ArrayList<String>) extractValueFactory.extractValue(row, "components");
+      assertEquals("10151", components.get(0));
       assertFalse(result.hasNext());
     }
   }

--- a/das-jira-connector/src/test/resources/mock-data/issues.json
+++ b/das-jira-connector/src/test/resources/mock-data/issues.json
@@ -115,9 +115,9 @@
             "name": "To Do"
           }
         },
-        "components": [],
+        "components": [{"self":"https://raw-labs.atlassian.net/rest/api/3/component/10151", "id":"10151", "name":"aComponent"}],
         "timeoriginalestimate": null,
-        "description": null,
+        "description": {"type":"doc","version":1.0,"content":[{"type":"paragraph","content":[{"type":"text","text":"do this"}]}]},
         "customfield_10653": null,
         "customfield_10600": null,
         "security": null,


### PR DESCRIPTION
The 'summary' and 'description' fields were being retrieved using incorrect keys, bypassing the necessary indirection through names. For instance, instead of using `f.get(names.get("Description"))`, and therefore extract the `"description"` key (lowercase `d`), the code directly called `f.get("Description")`.

Additionally, the `description` field has been updated to be an `any`, as real-world data indicates it can be a JSON object.