### PR TITLE
RD-15242: DAS doesn't pick the parent epic key

### DIFF
--- a/das-jira-connector/src/main/java/com/rawlabs/das/jira/tables/DASJiraJqlQueryBuilder.java
+++ b/das-jira-connector/src/main/java/com/rawlabs/das/jira/tables/DASJiraJqlQueryBuilder.java
@@ -62,7 +62,8 @@ public class DASJiraJqlQueryBuilder {
     return columnName.split("_")[0].toLowerCase();
   }
 
-  private static final Map<String, String> jqlKeyMap = Map.of("status_category", "statusCategory");
+  private static final Map<String, String> jqlKeyMap =
+      Map.of("status_category", "statusCategory", "epic_key", "parentEpic");
 
   public static String buildJqlQuery(List<Qual> quals) {
     StringBuilder jqlQuery = new StringBuilder();

--- a/das-jira-connector/src/main/java/com/rawlabs/das/jira/tables/definitions/DASJiraIssueTable.java
+++ b/das-jira-connector/src/main/java/com/rawlabs/das/jira/tables/definitions/DASJiraIssueTable.java
@@ -131,21 +131,24 @@ public class DASJiraIssueTable extends DASJiraIssueTransformationTable {
         statusCategory.map(s -> s.get("name")).orElse(null),
         columns);
 
+    // Epic key is (possibly) found as parent->key, but we'd report it
+    // as epic_key only if the parent issue type is "Epic". Which is found
+    // in parent->fields->name = "Epic"
     var epic =
         maybeFields
-            .map(f -> f.get(names.get("Parent")))
-            .map(p -> (Map<String, Object>) p)
-            .map(p -> p.get("fields"))
-            .map(f -> (Map<String, Object>) f)
-            .map(f -> f.get(names.get("Issue Type")))
-            .map(i -> (Map<String, Object>) i)
-            .map(i -> i.get("name"))
-            .map(
-                name -> {
-                  if (name.equals("Epic")) {
-                    return maybeFields.get().get("key");
-                  }
-                  return null;
+            .map(fields -> (Map<String, Object>) fields.get(names.get("Parent")))
+            .flatMap(
+                parent -> {
+                  return Optional.of((Map<String, Object>) parent.get("fields"))
+                      .map(f -> (Map<String, Object>) f.get(names.get("Issue Type")))
+                      .map(i -> i.get("name"))
+                      .map(
+                          name -> {
+                            if (name.equals("Epic")) {
+                              return (String) parent.get("key");
+                            }
+                            return null;
+                          });
                 });
 
     addToRow("epic_key", rowBuilder, epic.orElse(null), columns);

--- a/das-jira-connector/src/test/java/com/rawlabs/das/jira/tables/defnitions/DASJiraIssueTableTest.java
+++ b/das-jira-connector/src/test/java/com/rawlabs/das/jira/tables/defnitions/DASJiraIssueTableTest.java
@@ -62,6 +62,7 @@ public class DASJiraIssueTableTest extends BaseMockTest {
       assertEquals("SP-1", extractValueFactory.extractValue(row, "key"));
       assertEquals("Task", extractValueFactory.extractValue(row, "type"));
       assertEquals("test issue", extractValueFactory.extractValue(row, "summary"));
+      assertEquals("RD-15048", extractValueFactory.extractValue(row, "epic_key"));
       ObjectNode description = (ObjectNode) extractValueFactory.extractValue(row, "description");
       // Fetch the first text of the content ("do this")
       assertEquals(

--- a/das-jira-connector/src/test/resources/mock-data/issues.json
+++ b/das-jira-connector/src/test/resources/mock-data/issues.json
@@ -10,6 +10,43 @@
       "self": "https://raw-labs.atlassian.net/rest/api/3/issue/33060",
       "key": "SP-1",
       "fields": {
+        "parent": {
+          "id": "33109",
+          "key": "RD-15048",
+          "self": "https://raw-labs.atlassian.net/rest/api/2/issue/33109",
+          "fields": {
+            "summary": "New onboarding - (UI, Repose, GitHub repos, Monitoring) ",
+            "status": {
+              "self": "https://raw-labs.atlassian.net/rest/api/2/status/3",
+              "description": "This issue is being actively worked on at the moment by the assignee.",
+              "iconUrl": "https://raw-labs.atlassian.net/images/icons/statuses/inprogress.png",
+              "name": "In Progress",
+              "id": "3",
+              "statusCategory": {
+                "self": "https://raw-labs.atlassian.net/rest/api/2/statuscategory/4",
+                "id": 4,
+                "key": "indeterminate",
+                "colorName": "yellow",
+                "name": "In Progress"
+              }
+            },
+            "priority": {
+              "self": "https://raw-labs.atlassian.net/rest/api/2/priority/3",
+              "iconUrl": "https://raw-labs.atlassian.net/images/icons/priorities/medium.svg",
+              "name": "Medium",
+              "id": "3"
+            },
+            "issuetype": {
+              "self": "https://raw-labs.atlassian.net/rest/api/2/issuetype/10000",
+              "id": "10000",
+              "description": "A big user story that needs to be broken down. Created by JIRA Software - do not edit or delete.",
+              "iconUrl": "https://raw-labs.atlassian.net/images/icons/issuetypes/epic.svg",
+              "name": "Epic",
+              "subtask": false,
+              "hierarchyLevel": 1
+            }
+          }
+        },
         "statuscategorychangedate": "2024-10-18T13:53:06.820+0200",
         "issuetype": {
           "self": "https://raw-labs.atlassian.net/rest/api/3/issuetype/10117",
@@ -115,9 +152,29 @@
             "name": "To Do"
           }
         },
-        "components": [{"self":"https://raw-labs.atlassian.net/rest/api/3/component/10151", "id":"10151", "name":"aComponent"}],
+        "components": [
+          {
+            "self": "https://raw-labs.atlassian.net/rest/api/3/component/10151",
+            "id": "10151",
+            "name": "aComponent"
+          }
+        ],
         "timeoriginalestimate": null,
-        "description": {"type":"doc","version":1.0,"content":[{"type":"paragraph","content":[{"type":"text","text":"do this"}]}]},
+        "description": {
+          "type": "doc",
+          "version": 1.0,
+          "content": [
+            {
+              "type": "paragraph",
+              "content": [
+                {
+                  "type": "text",
+                  "text": "do this"
+                }
+              ]
+            }
+          ]
+        },
         "customfield_10653": null,
         "customfield_10600": null,
         "security": null,
@@ -214,6 +271,7 @@
     }
   ],
   "names": {
+    "parent": "Parent",
     "statuscategorychangedate": "Status Category Changed",
     "issuetype": "Issue Type",
     "timespent": "Time Spent",


### PR DESCRIPTION
Added a test to make sure the value is picked.

Also run live:
```
bgaidioz=# SELECT key, epic_key FROM jira.jira_issue WHERE key = 'RD-15122';
   key    | epic_key 
----------+----------
 RD-15122 | 
(1 row)
```
now:
```
bgaidioz=# SELECT key, epic_key FROM jira.jira_issue WHERE key = 'RD-15122';
   key    | epic_key 
----------+----------
 RD-15122 | RD-15048
(1 row)
```
And manually tested the filtering (fixed in the PR):
```
bgaidioz=# SELECT key, epic_key FROM jira.jira_issue WHERE epic_key = 'RD-15048';
ERROR:  Error in python: _MultiThreadedRendezvous
DETAIL:  <_MultiThreadedRendezvous of RPC that terminated with:
	status = StatusCode.UNKNOWN
	details = "Message: 
HTTP response code: 400
HTTP response body: {"errorMessages":["Field 'epic' does not exist or you do not have permission to view it."],"warningMessages":[]}
```
now
```
bgaidioz=# SELECT key, epic_key FROM jira.jira_issue WHERE epic_key = 'RD-15048';
   key    | epic_key 
----------+----------
 RD-15197 | RD-15048
 RD-15195 | RD-15048
 RD-15175 | RD-15048
 RD-15173 | RD-15048
 RD-15159 | RD-15048
 RD-15146 | RD-15048
 RD-15145 | RD-15048
 RD-15137 | RD-15048
 RD-15133 | RD-15048
 RD-15125 | RD-15048
 RD-15124 | RD-15048
 RD-15122 | RD-15048
 RD-15121 | RD-15048
 RD-15120 | RD-15048
 RD-15066 | RD-15048
 RD-15065 | RD-15048
 RD-15064 | RD-15048
 RD-15063 | RD-15048
 RD-15060 | RD-15048
 RD-15059 | RD-15048
 RD-15057 | RD-15048
 RD-15053 | RD-15048
 RD-15052 | RD-15048
 RD-15049 | RD-15048
(24 rows)
```