### PR TITLE
Fixed RD-15247: IS [NOT] NULL generates wrong JQL

### DIFF
--- a/das-jira-connector/src/main/java/com/rawlabs/das/jira/tables/DASJiraJqlQueryBuilder.java
+++ b/das-jira-connector/src/main/java/com/rawlabs/das/jira/tables/DASJiraJqlQueryBuilder.java
@@ -73,9 +73,21 @@ public class DASJiraJqlQueryBuilder {
         .forEach(
             q -> {
               String column = getIssueJqlKey(q.getFieldName());
-              String operator = mapOperator(q.getSimpleQual().getOperator());
-              String value = mapValue(q.getSimpleQual().getValue());
-              joiner.add(column + " " + operator + " " + value);
+              var rawOperator = q.getSimpleQual().getOperator();
+              var rawValue = q.getSimpleQual().getValue();
+              if (rawValue.hasNull()) {
+                if (rawOperator.hasEquals()) {
+                  joiner.add(column + " IS EMPTY");
+                } else if (rawOperator.hasNotEquals()) {
+                  joiner.add(column + " IS NOT EMPTY");
+                } else {
+                  throw new IllegalArgumentException("Unexpected operator: " + rawOperator);
+                }
+              } else {
+                String value = mapValue(rawValue);
+                String operator = mapOperator(rawOperator);
+                joiner.add(column + " " + operator + " " + value);
+              }
             });
     jqlQuery.append(joiner);
     return jqlQuery.toString();


### PR DESCRIPTION
Main issue is that we do not rewrite `IS NULL` or `IS NOT NULL` correctly. They come as `x = NULL` or `x != NULL`. In JQL they have to be rewritten as `IS EMPTY` or `IS NOT EMPTY`. That's what is fixed here.

It's now possible to filter issues without a description (or with a description with `IS NOT NULL`).
```
SELECT components          
FROM jira.jira_issue
WHERE description IS NULL
LIMIT 10;
```