### PR TITLE
Fixed RD-15249: Column rank wrongly advertised as string

### DIFF
--- a/das-jira-connector/src/main/java/com/rawlabs/das/jira/tables/definitions/DASJiraDashboardTable.java
+++ b/das-jira-connector/src/main/java/com/rawlabs/das/jira/tables/definitions/DASJiraDashboardTable.java
@@ -203,7 +203,7 @@ public class DASJiraDashboardTable extends DASJiraTable {
             "popularity",
             "The number of users who have this dashboard as a favorite.",
             createStringType()));
-    columns.put("rank", createColumn("rank", "The rank of this dashboard.", createStringType()));
+    columns.put("rank", createColumn("rank", "The rank of this dashboard.", createIntType()));
     columns.put("view", createColumn("view", "The URL of the dashboard.", createStringType()));
     columns.put(
         "edit_permissions",


### PR DESCRIPTION
Column "rank" is documented as `StringType` but is filled with an `Integer` value:
```scala
      addToRow("rank", rowBuilder, dashboard.getRank(), columns);
```
and `getRank` is an `Integer`:
```java
  /**
   * The rank of this dashboard.
   * @return rank
   */
  @javax.annotation.Nullable
  public Integer getRank() {
    return rank;
  }
```