### PR TITLE
RD-15380: Strip HTTP headers from errors

### DIFF
--- a/das-jira-connector/pom.xml
+++ b/das-jira-connector/pom.xml
@@ -132,7 +132,7 @@
         <maven-shade-plugin-version>3.4.1</maven-shade-plugin-version>
 
         <!-- RAW Labs Dependencies -->
-        <das-server-scala-version>0.3.0</das-server-scala-version>
+        <das-server-scala-version>0.4.1</das-server-scala-version>
         <jira-rest-client-version>1.0-SNAPSHOT</jira-rest-client-version>
         <protocol-das.version>1.0.0</protocol-das.version>
 

--- a/das-jira-connector/src/main/java/com/rawlabs/das/jira/DASJiraUnexpectedError.java
+++ b/das-jira-connector/src/main/java/com/rawlabs/das/jira/DASJiraUnexpectedError.java
@@ -1,0 +1,14 @@
+package com.rawlabs.das.jira;
+
+/**
+ * DASJiraApiException wraps an ApiException (from either the platform or software API) to propagate
+ * only the response body as the error message. The original ApiException message often includes
+ * extensive HTTP header details that are not useful for DAS clients.
+ */
+public class DASJiraUnexpectedError extends RuntimeException {
+
+  public DASJiraUnexpectedError(Throwable t) {
+    super("unexpected error", t);
+  }
+
+}

--- a/das-jira-connector/src/main/java/com/rawlabs/das/jira/initializer/DASJiraInitializer.java
+++ b/das-jira-connector/src/main/java/com/rawlabs/das/jira/initializer/DASJiraInitializer.java
@@ -2,6 +2,8 @@ package com.rawlabs.das.jira.initializer;
 
 import com.rawlabs.das.jira.initializer.auth.DASJiraAuthStrategy;
 import com.rawlabs.das.jira.initializer.auth.DASJiraAuthStrategyFactory;
+import com.rawlabs.das.sdk.DASSdkInvalidArgumentException;
+
 import java.util.Map;
 
 public class DASJiraInitializer {
@@ -9,7 +11,7 @@ public class DASJiraInitializer {
   public static com.rawlabs.das.jira.rest.platform.ApiClient initializePlatform(
       Map<String, String> options) {
     if (options.get("base_url") == null) {
-      throw new IllegalArgumentException("base_url is required");
+      throw new DASSdkInvalidArgumentException("base_url is required");
     }
     com.rawlabs.das.jira.rest.platform.ApiClient apiClient =
         new com.rawlabs.das.jira.rest.platform.ApiClient();
@@ -22,7 +24,7 @@ public class DASJiraInitializer {
   public static com.rawlabs.das.jira.rest.software.ApiClient initializeSoftware(
       Map<String, String> options) {
     if (options.get("base_url") == null) {
-      throw new IllegalArgumentException("base_url is required");
+      throw new DASSdkInvalidArgumentException("base_url is required");
     }
     com.rawlabs.das.jira.rest.software.ApiClient apiClient =
         new com.rawlabs.das.jira.rest.software.ApiClient();

--- a/das-jira-connector/src/main/java/com/rawlabs/das/jira/initializer/auth/DASJiraAuthStrategyFactory.java
+++ b/das-jira-connector/src/main/java/com/rawlabs/das/jira/initializer/auth/DASJiraAuthStrategyFactory.java
@@ -1,12 +1,14 @@
 package com.rawlabs.das.jira.initializer.auth;
 
+import com.rawlabs.das.sdk.DASSdkInvalidArgumentException;
+
 import java.util.Map;
 
 public class DASJiraAuthStrategyFactory {
   public static DASJiraAuthStrategy createAuthStrategy(Map<String, String> options) {
     if (isBearerAuth(options)) return new DASJiraOAuth2AuthStrategy();
     else if (isBasicAuth(options)) return new DasJiraBasicAuthStrategy();
-    else throw new IllegalArgumentException("Invalid authentication options");
+    else throw new DASSdkInvalidArgumentException("Invalid authentication option");
   }
 
   private static boolean isBearerAuth(Map<String, String> options) {

--- a/das-jira-connector/src/main/java/com/rawlabs/das/jira/tables/DASJiraIssueTransformationTable.java
+++ b/das-jira-connector/src/main/java/com/rawlabs/das/jira/tables/DASJiraIssueTransformationTable.java
@@ -1,7 +1,7 @@
 package com.rawlabs.das.jira.tables;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.rawlabs.das.sdk.DASSdkException;
+import com.rawlabs.das.jira.DASJiraUnexpectedError;
 import com.rawlabs.protocol.das.v1.tables.Row;
 import java.util.*;
 
@@ -83,7 +83,7 @@ public abstract class DASJiraIssueTransformationTable extends DASJiraTable {
       // 'description' is an object, so we need to serialize it. It's then sent as 'any'.
       addToRow("description", rowBuilder, objectMapper.writeValueAsString(description), columns);
     } catch (JsonProcessingException e) {
-      throw new DASSdkException("error processing 'description'", e);
+      throw new DASJiraUnexpectedError(e);
     }
 
     addToRow(
@@ -147,7 +147,7 @@ public abstract class DASJiraIssueTransformationTable extends DASJiraTable {
     try {
       addToRow("fields", rowBuilder, objectMapper.writeValueAsString(fields), columns);
     } catch (JsonProcessingException e) {
-      throw new DASSdkException(e.getMessage());
+      throw new DASJiraUnexpectedError(e);
     }
 
     addToRow(
@@ -173,7 +173,7 @@ public abstract class DASJiraIssueTransformationTable extends DASJiraTable {
     try {
       addToRow("tags", rowBuilder, objectMapper.writeValueAsString(tags), columns);
     } catch (JsonProcessingException e) {
-      throw new DASSdkException(e.getMessage());
+      throw new DASJiraUnexpectedError(e);
     }
   }
 }

--- a/das-jira-connector/src/main/java/com/rawlabs/das/jira/tables/definitions/DASJiraAdvancedSettingsTable.java
+++ b/das-jira-connector/src/main/java/com/rawlabs/das/jira/tables/definitions/DASJiraAdvancedSettingsTable.java
@@ -10,7 +10,6 @@ import com.rawlabs.das.jira.rest.platform.model.ApplicationProperty;
 import com.rawlabs.das.jira.rest.platform.model.SimpleApplicationPropertyBean;
 import com.rawlabs.das.jira.tables.*;
 import com.rawlabs.das.sdk.DASExecuteResult;
-import com.rawlabs.das.sdk.DASSdkException;
 import com.rawlabs.protocol.das.v1.query.PathKey;
 import com.rawlabs.protocol.das.v1.query.Qual;
 import com.rawlabs.protocol.das.v1.query.SortKey;
@@ -58,7 +57,7 @@ public class DASJiraAdvancedSettingsTable extends DASJiraTable {
           jiraSettingsApi.setApplicationProperty(id, applicationPropertyBean);
       return toRow(applicationProperty, List.of());
     } catch (ApiException e) {
-      throw new DASSdkException(e.getMessage(), e);
+      throw makeSdkException(e);
     }
   }
 
@@ -89,8 +88,7 @@ public class DASJiraAdvancedSettingsTable extends DASJiraTable {
         }
       };
     } catch (ApiException e) {
-      throw new DASSdkException(
-          "Failed to fetch advanced settings: %s".formatted(e.getResponseBody()), e);
+      throw makeSdkException(e);
     }
   }
 

--- a/das-jira-connector/src/main/java/com/rawlabs/das/jira/tables/definitions/DASJiraBacklogIssueTable.java
+++ b/das-jira-connector/src/main/java/com/rawlabs/das/jira/tables/definitions/DASJiraBacklogIssueTable.java
@@ -13,7 +13,7 @@ import com.rawlabs.das.jira.tables.results.DASJiraPage;
 import com.rawlabs.das.jira.tables.results.DASJiraPaginatedResult;
 import com.rawlabs.das.jira.tables.results.DASJiraWithParentTableResult;
 import com.rawlabs.das.sdk.DASExecuteResult;
-import com.rawlabs.das.sdk.DASSdkException;
+import com.rawlabs.das.sdk.DASSdkInvalidArgumentException;
 import com.rawlabs.protocol.das.v1.query.Qual;
 import com.rawlabs.protocol.das.v1.query.SortKey;
 import com.rawlabs.protocol.das.v1.tables.Column;
@@ -50,7 +50,7 @@ public class DASJiraBacklogIssueTable extends DASJiraIssueTransformationTable {
     String issueId = (String) extractValueFactory.extractValue(rowId);
 
     if (boardId == null || issueId == null) {
-      throw new DASSdkException("The only update operation allowed is moving issues to backlog.");
+      throw new DASSdkInvalidArgumentException("The only update operation allowed is moving issues to backlog.");
     }
 
     MoveIssuesToBacklogForBoardRequest moveIssuesToBacklogForBoardRequest =
@@ -59,7 +59,7 @@ public class DASJiraBacklogIssueTable extends DASJiraIssueTransformationTable {
     try {
       boardApi.moveIssuesToBoard(boardId, moveIssuesToBacklogForBoardRequest);
     } catch (ApiException e) {
-      throw new DASSdkException(e.getMessage(), e);
+      throw makeSdkException(e);
     }
     return newValues.toBuilder()
         .addColumns(
@@ -103,7 +103,7 @@ public class DASJiraBacklogIssueTable extends DASJiraIssueTransformationTable {
                   Long.valueOf(Objects.requireNonNullElse(searchResults.getTotal(), 0)),
                   searchResults.getNames());
             } catch (ApiException e) {
-              throw new DASSdkException(e.getMessage(), e);
+              throw makeSdkException(e);
             }
           }
         };

--- a/das-jira-connector/src/main/java/com/rawlabs/das/jira/tables/definitions/DASJiraComponentTable.java
+++ b/das-jira-connector/src/main/java/com/rawlabs/das/jira/tables/definitions/DASJiraComponentTable.java
@@ -13,7 +13,6 @@ import com.rawlabs.das.jira.tables.results.DASJiraPage;
 import com.rawlabs.das.jira.tables.results.DASJiraPaginatedResult;
 import com.rawlabs.das.jira.tables.results.DASJiraWithParentTableResult;
 import com.rawlabs.das.sdk.DASExecuteResult;
-import com.rawlabs.das.sdk.DASSdkException;
 import com.rawlabs.protocol.das.v1.query.PathKey;
 import com.rawlabs.protocol.das.v1.query.Qual;
 import com.rawlabs.protocol.das.v1.query.SortKey;
@@ -80,7 +79,7 @@ public class DASJiraComponentTable extends DASJiraTable {
           this.projectComponentsApi.createComponent(createProjectComponent(row));
       return toRow(toComponentWithCount(inserted), List.of());
     } catch (ApiException e) {
-      throw new DASSdkException(e.getMessage());
+      throw makeSdkException(e);
     }
   }
 
@@ -93,7 +92,7 @@ public class DASJiraComponentTable extends DASJiraTable {
       projectComponentsApi.updateComponent(
           (String) extractValueFactory.extractValue(rowId), createProjectComponent(newValues));
     } catch (ApiException e) {
-      throw new RuntimeException(e);
+      throw makeSdkException(e);
     }
     return super.update(rowId, newValues);
   }
@@ -102,7 +101,7 @@ public class DASJiraComponentTable extends DASJiraTable {
     try {
       projectComponentsApi.deleteComponent((String) extractValueFactory.extractValue(rowId), null);
     } catch (ApiException e) {
-      throw new RuntimeException(e);
+      throw makeSdkException(e);
     }
   }
 
@@ -133,8 +132,7 @@ public class DASJiraComponentTable extends DASJiraTable {
                       null);
               return new DASJiraPage<>(components.getValues(), components.getTotal());
             } catch (ApiException e) {
-              throw new DASSdkException(
-                  "Error fetching components: %s".formatted(e.getResponseBody()), e);
+              throw makeSdkException(e);
             }
           }
         };
@@ -259,7 +257,7 @@ public class DASJiraComponentTable extends DASJiraTable {
           realAssigneeType,
           projectComponent.getSelf());
     } catch (ApiException e) {
-      throw new DASSdkException(e.getMessage(), e);
+      throw makeSdkException(e);
     }
   }
 

--- a/das-jira-connector/src/main/java/com/rawlabs/das/jira/tables/definitions/DASJiraDashboardTable.java
+++ b/das-jira-connector/src/main/java/com/rawlabs/das/jira/tables/definitions/DASJiraDashboardTable.java
@@ -5,6 +5,7 @@ import static com.rawlabs.das.jira.utils.factory.type.TypeFactory.*;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.rawlabs.das.jira.DASJiraUnexpectedError;
 import com.rawlabs.das.jira.rest.platform.ApiException;
 import com.rawlabs.das.jira.rest.platform.api.DashboardsApi;
 import com.rawlabs.das.jira.rest.platform.model.*;
@@ -12,7 +13,6 @@ import com.rawlabs.das.jira.tables.DASJiraTable;
 import com.rawlabs.das.jira.tables.results.DASJiraPage;
 import com.rawlabs.das.jira.tables.results.DASJiraPaginatedResult;
 import com.rawlabs.das.sdk.DASExecuteResult;
-import com.rawlabs.das.sdk.DASSdkException;
 import com.rawlabs.protocol.das.v1.query.PathKey;
 import com.rawlabs.protocol.das.v1.query.Qual;
 import com.rawlabs.protocol.das.v1.query.SortKey;
@@ -70,8 +70,10 @@ public class DASJiraDashboardTable extends DASJiraTable {
     try {
       Dashboard result = dashboardsApi.createDashboard(getDashboardDetails(row), null);
       return toRow(result, List.of());
-    } catch (ApiException | IOException e) {
-      throw new DASSdkException(e.getMessage(), e);
+    } catch (ApiException e) {
+      throw makeSdkException(e);
+    } catch (IOException e) {
+      throw new DASJiraUnexpectedError(e);
     }
   }
 
@@ -84,8 +86,10 @@ public class DASJiraDashboardTable extends DASJiraTable {
               getDashboardDetails(newValues),
               null);
       return toRow(result, List.of());
-    } catch (ApiException | IOException e) {
-      throw new RuntimeException(e);
+    } catch (ApiException e) {
+      throw makeSdkException(e);
+    } catch (IOException e) {
+      throw new DASJiraUnexpectedError(e);
     }
   }
 
@@ -94,7 +98,7 @@ public class DASJiraDashboardTable extends DASJiraTable {
     try {
       dashboardsApi.deleteDashboard(extractValueFactory.extractValue(rowId).toString());
     } catch (ApiException e) {
-      throw new RuntimeException(e);
+      throw makeSdkException(e);
     }
   }
 
@@ -117,7 +121,7 @@ public class DASJiraDashboardTable extends DASJiraTable {
           return new DASJiraPage<>(
               page.getDashboards(), Long.valueOf(Objects.requireNonNullElse(page.getTotal(), 0)));
         } catch (ApiException e) {
-          throw new RuntimeException(e);
+          throw makeSdkException(e);
         }
       }
     };
@@ -165,7 +169,7 @@ public class DASJiraDashboardTable extends DASJiraTable {
       addToRow("title", rowBuilder, dashboard.getName(), columns);
       return rowBuilder.build();
     } catch (JsonProcessingException e) {
-      throw new DASSdkException(e.getMessage());
+      throw new DASJiraUnexpectedError(e);
     }
   }
 

--- a/das-jira-connector/src/main/java/com/rawlabs/das/jira/tables/definitions/DASJiraEpicTable.java
+++ b/das-jira-connector/src/main/java/com/rawlabs/das/jira/tables/definitions/DASJiraEpicTable.java
@@ -9,7 +9,6 @@ import com.rawlabs.das.jira.rest.software.model.Epic;
 import com.rawlabs.das.jira.rest.software.model.EpicSearchResult;
 import com.rawlabs.das.jira.tables.DASJiraTable;
 import com.rawlabs.das.sdk.DASExecuteResult;
-import com.rawlabs.das.sdk.DASSdkException;
 import com.rawlabs.protocol.das.v1.query.Qual;
 import com.rawlabs.protocol.das.v1.query.SortKey;
 import com.rawlabs.protocol.das.v1.tables.ColumnDefinition;
@@ -43,7 +42,7 @@ public class DASJiraEpicTable extends DASJiraTable {
       EpicSearchResult result = epicApi.searchPaginatedEpics(0, withMaxResultOrLimit(limit));
       return fromRowIterator(result.getValues().stream().map(v -> toRow(v, columns)).iterator());
     } catch (ApiException e) {
-      throw new DASSdkException(e.getMessage());
+      throw makeSdkException(e);
     }
   }
 

--- a/das-jira-connector/src/main/java/com/rawlabs/das/jira/tables/definitions/DASJiraGlobalSettingTable.java
+++ b/das-jira-connector/src/main/java/com/rawlabs/das/jira/tables/definitions/DASJiraGlobalSettingTable.java
@@ -4,12 +4,12 @@ import static com.rawlabs.das.jira.utils.factory.table.ColumnFactory.createColum
 import static com.rawlabs.das.jira.utils.factory.type.TypeFactory.*;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.rawlabs.das.jira.DASJiraUnexpectedError;
 import com.rawlabs.das.jira.rest.platform.ApiException;
 import com.rawlabs.das.jira.rest.platform.api.JiraSettingsApi;
 import com.rawlabs.das.jira.rest.platform.model.ModelConfiguration;
 import com.rawlabs.das.jira.tables.DASJiraTable;
 import com.rawlabs.das.sdk.DASExecuteResult;
-import com.rawlabs.das.sdk.DASSdkException;
 import com.rawlabs.protocol.das.v1.query.Qual;
 import com.rawlabs.protocol.das.v1.query.SortKey;
 import com.rawlabs.protocol.das.v1.tables.ColumnDefinition;
@@ -44,7 +44,7 @@ public class DASJiraGlobalSettingTable extends DASJiraTable {
       Iterator<Row> iterator = List.of(toRow(config, columns)).iterator();
       return fromRowIterator(iterator);
     } catch (ApiException e) {
-      throw new RuntimeException(e);
+      throw makeSdkException(e);
     }
   }
 
@@ -73,7 +73,7 @@ public class DASJiraGlobalSettingTable extends DASJiraTable {
                   try {
                     return objectMapper.writeValueAsString(c);
                   } catch (JsonProcessingException e) {
-                    throw new DASSdkException(e.getMessage(), e);
+                    throw new DASJiraUnexpectedError(e);
                   }
                 })
             .orElse(null),

--- a/das-jira-connector/src/main/java/com/rawlabs/das/jira/tables/definitions/DASJiraGroupTable.java
+++ b/das-jira-connector/src/main/java/com/rawlabs/das/jira/tables/definitions/DASJiraGroupTable.java
@@ -13,7 +13,6 @@ import com.rawlabs.das.jira.tables.DASJiraTable;
 import com.rawlabs.das.jira.tables.results.DASJiraPage;
 import com.rawlabs.das.jira.tables.results.DASJiraPaginatedResult;
 import com.rawlabs.das.sdk.DASExecuteResult;
-import com.rawlabs.das.sdk.DASSdkException;
 import com.rawlabs.protocol.das.v1.query.PathKey;
 import com.rawlabs.protocol.das.v1.query.Qual;
 import com.rawlabs.protocol.das.v1.query.SortKey;
@@ -61,7 +60,7 @@ public class DASJiraGroupTable extends DASJiraTable {
       groupDetails.setGroupId(group.getGroupId());
       return toRow(groupDetails, List.of(), List.of(), List.of());
     } catch (ApiException e) {
-      throw new DASSdkException(e.getMessage());
+      throw makeSdkException(e);
     }
   }
 
@@ -71,7 +70,7 @@ public class DASJiraGroupTable extends DASJiraTable {
       this.groupsApi.removeGroup(
           null, (String) extractValueFactory.extractValue(rowId), null, null);
     } catch (ApiException e) {
-      throw new DASSdkException(e.getMessage());
+      throw makeSdkException(e);
     }
   }
 
@@ -112,7 +111,7 @@ public class DASJiraGroupTable extends DASJiraTable {
                             withMaxResultOrLimit(limit));
                     return new DASJiraPage<>(result.getValues(), result.getTotal());
                   } catch (ApiException e) {
-                    throw new DASSdkException(e.getMessage());
+                    throw makeSdkException(e);
                   }
                 }
               }) {
@@ -134,7 +133,7 @@ public class DASJiraGroupTable extends DASJiraTable {
               groupsApi.bulkGetGroups(offset, withMaxResultOrLimit(limit), null, null, null, null);
           return new DASJiraPage<>(result.getValues(), result.getTotal());
         } catch (ApiException e) {
-          throw new DASSdkException(e.getMessage());
+          throw makeSdkException(e);
         }
       }
     };

--- a/das-jira-connector/src/main/java/com/rawlabs/das/jira/tables/definitions/DASJiraIssueCommentTable.java
+++ b/das-jira-connector/src/main/java/com/rawlabs/das/jira/tables/definitions/DASJiraIssueCommentTable.java
@@ -3,6 +3,7 @@ package com.rawlabs.das.jira.tables.definitions;
 import static com.rawlabs.das.jira.utils.factory.table.ColumnFactory.createColumn;
 import static com.rawlabs.das.jira.utils.factory.type.TypeFactory.*;
 
+import com.rawlabs.das.jira.DASJiraUnexpectedError;
 import com.rawlabs.das.jira.rest.platform.ApiException;
 import com.rawlabs.das.jira.rest.platform.api.*;
 import com.rawlabs.das.jira.rest.platform.model.Comment;
@@ -12,7 +13,6 @@ import com.rawlabs.das.jira.tables.results.DASJiraPage;
 import com.rawlabs.das.jira.tables.results.DASJiraPaginatedResult;
 import com.rawlabs.das.jira.tables.results.DASJiraWithParentTableResult;
 import com.rawlabs.das.sdk.DASExecuteResult;
-import com.rawlabs.das.sdk.DASSdkException;
 import com.rawlabs.protocol.das.v1.query.Qual;
 import com.rawlabs.protocol.das.v1.query.SortKey;
 import com.rawlabs.protocol.das.v1.tables.ColumnDefinition;
@@ -61,7 +61,7 @@ public class DASJiraIssueCommentTable extends DASJiraTable {
           UserDetails.fromJson(extractValueFactory.extractValue(row, "update_author").toString()),
           extractValueFactory.extractValue(row, "updated").toString());
     } catch (IOException e) {
-      throw new DASSdkException(e.getMessage(), e);
+      throw new DASJiraUnexpectedError(e);
     }
   }
 
@@ -71,7 +71,7 @@ public class DASJiraIssueCommentTable extends DASJiraTable {
       Comment resultComment = issueCommentsApi.addComment(issueIdOrKey, extractComment(row), null);
       return toRow(resultComment, issueIdOrKey, List.of());
     } catch (ApiException e) {
-      throw new DASSdkException(e.getMessage(), e);
+      throw makeSdkException(e);
     }
   }
 
@@ -88,7 +88,7 @@ public class DASJiraIssueCommentTable extends DASJiraTable {
               null);
       return toRow(comment, issueIdOrKey, List.of());
     } catch (ApiException e) {
-      throw new RuntimeException(e);
+      throw makeSdkException(e);
     }
   }
 
@@ -114,7 +114,7 @@ public class DASJiraIssueCommentTable extends DASJiraTable {
                       issueId, offset, withMaxResultOrLimit(limit), withOrderBy(sortKeys), null);
               return new DASJiraPage<>(result.getComments(), result.getTotal());
             } catch (ApiException e) {
-              throw new DASSdkException(e.getResponseBody());
+              throw makeSdkException(e);
             }
           }
         };

--- a/das-jira-connector/src/main/java/com/rawlabs/das/jira/tables/definitions/DASJiraIssueTable.java
+++ b/das-jira-connector/src/main/java/com/rawlabs/das/jira/tables/definitions/DASJiraIssueTable.java
@@ -13,7 +13,6 @@ import com.rawlabs.das.jira.tables.DASJiraJqlQueryBuilder;
 import com.rawlabs.das.jira.tables.results.DASJiraPage;
 import com.rawlabs.das.jira.tables.results.DASJiraPaginatedResult;
 import com.rawlabs.das.sdk.DASExecuteResult;
-import com.rawlabs.das.sdk.DASSdkException;
 import com.rawlabs.protocol.das.v1.query.Qual;
 import com.rawlabs.protocol.das.v1.query.SortKey;
 import com.rawlabs.protocol.das.v1.tables.ColumnDefinition;
@@ -54,7 +53,7 @@ public class DASJiraIssueTable extends DASJiraIssueTransformationTable {
       addToRow("self", builder, result.getSelf(), List.of());
       return builder.build();
     } catch (ApiException e) {
-      throw new DASSdkException(e.getMessage());
+      throw makeSdkException(e);
     }
   }
 
@@ -62,7 +61,7 @@ public class DASJiraIssueTable extends DASJiraIssueTransformationTable {
     try {
       issuesApi.deleteIssue(extractValueFactory.extractValue(rowId).toString(), null);
     } catch (ApiException e) {
-      throw new DASSdkException(e.getMessage());
+      throw makeSdkException(e);
     }
   }
 
@@ -101,7 +100,7 @@ public class DASJiraIssueTable extends DASJiraIssueTransformationTable {
               Long.valueOf(Objects.requireNonNullElse(result.getTotal(), 0)),
               result.getNames());
         } catch (ApiException e) {
-          throw new DASSdkException(e.getMessage());
+          throw makeSdkException(e);
         }
       }
     };

--- a/das-jira-connector/src/main/java/com/rawlabs/das/jira/tables/definitions/DASJiraIssueTypeTable.java
+++ b/das-jira-connector/src/main/java/com/rawlabs/das/jira/tables/definitions/DASJiraIssueTypeTable.java
@@ -8,7 +8,6 @@ import com.rawlabs.das.jira.rest.platform.api.IssueTypesApi;
 import com.rawlabs.das.jira.rest.platform.model.*;
 import com.rawlabs.das.jira.tables.DASJiraTable;
 import com.rawlabs.das.sdk.DASExecuteResult;
-import com.rawlabs.das.sdk.DASSdkException;
 import com.rawlabs.protocol.das.v1.query.PathKey;
 import com.rawlabs.protocol.das.v1.query.Qual;
 import com.rawlabs.protocol.das.v1.query.SortKey;
@@ -58,7 +57,7 @@ public class DASJiraIssueTypeTable extends DASJiraTable {
       issueTypeCreateBean.setHierarchyLevel(hierarchyLevel);
       return toRow(issueTypesApi.createIssueType(issueTypeCreateBean), List.of());
     } catch (ApiException e) {
-      throw new DASSdkException(e.getMessage());
+      throw makeSdkException(e);
     }
   }
 
@@ -69,7 +68,7 @@ public class DASJiraIssueTypeTable extends DASJiraTable {
       var result = issueTypesApi.updateIssueType(id, issueTypeUpdateBean);
       return toRow(result, List.of());
     } catch (ApiException e) {
-      throw new RuntimeException(e);
+      throw makeSdkException(e);
     }
   }
 
@@ -78,7 +77,7 @@ public class DASJiraIssueTypeTable extends DASJiraTable {
     try {
       issueTypesApi.deleteIssueType(id, null);
     } catch (ApiException e) {
-      throw new DASSdkException(e.getMessage());
+      throw makeSdkException(e);
     }
   }
 
@@ -89,7 +88,7 @@ public class DASJiraIssueTypeTable extends DASJiraTable {
       return fromRowIterator(
           issueTypesApi.getIssueAllTypes().stream().map(i -> toRow(i, columns)).iterator());
     } catch (ApiException e) {
-      throw new RuntimeException(e);
+      throw makeSdkException(e);
     }
   }
 

--- a/das-jira-connector/src/main/java/com/rawlabs/das/jira/tables/definitions/DASJiraIssueWorklogTable.java
+++ b/das-jira-connector/src/main/java/com/rawlabs/das/jira/tables/definitions/DASJiraIssueWorklogTable.java
@@ -4,6 +4,7 @@ import static com.rawlabs.das.jira.utils.factory.table.ColumnFactory.createColum
 import static com.rawlabs.das.jira.utils.factory.type.TypeFactory.*;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.rawlabs.das.jira.DASJiraUnexpectedError;
 import com.rawlabs.das.jira.rest.platform.ApiException;
 import com.rawlabs.das.jira.rest.platform.api.IssueSearchApi;
 import com.rawlabs.das.jira.rest.platform.api.IssueWorklogsApi;
@@ -16,7 +17,6 @@ import com.rawlabs.das.jira.tables.results.DASJiraPage;
 import com.rawlabs.das.jira.tables.results.DASJiraPaginatedResult;
 import com.rawlabs.das.jira.tables.results.DASJiraWithParentTableResult;
 import com.rawlabs.das.sdk.DASExecuteResult;
-import com.rawlabs.das.sdk.DASSdkException;
 import com.rawlabs.protocol.das.v1.query.Qual;
 import com.rawlabs.protocol.das.v1.query.SortKey;
 import com.rawlabs.protocol.das.v1.tables.ColumnDefinition;
@@ -66,7 +66,7 @@ public class DASJiraIssueWorklogTable extends DASJiraTable {
           UserDetails.fromJson(updateAuthor.toJson()),
           extractValueFactory.extractValue(row, "updated").toString());
     } catch (IOException | URISyntaxException e) {
-      throw new DASSdkException(e.getMessage());
+      throw new DASJiraUnexpectedError(e);
     }
   }
 
@@ -78,7 +78,7 @@ public class DASJiraIssueWorklogTable extends DASJiraTable {
               worklog.getIssueId(), worklog, null, null, null, null, null, null);
       return toRow(resultWorklog, List.of());
     } catch (ApiException e) {
-      throw new DASSdkException(e.getMessage(), e);
+      throw makeSdkException(e);
     }
   }
 
@@ -97,7 +97,7 @@ public class DASJiraIssueWorklogTable extends DASJiraTable {
               null);
       return toRow(resultWorklog, List.of());
     } catch (ApiException e) {
-      throw new DASSdkException(e.getMessage());
+      throw makeSdkException(e);
     }
   }
 
@@ -125,7 +125,7 @@ public class DASJiraIssueWorklogTable extends DASJiraTable {
                   result.getWorklogs(),
                   Long.valueOf(Objects.requireNonNullElse(result.getTotal(), 0)));
             } catch (ApiException e) {
-              throw new RuntimeException(e);
+              throw makeSdkException(e);
             }
           }
         };
@@ -166,7 +166,7 @@ public class DASJiraIssueWorklogTable extends DASJiraTable {
           objectMapper.writeValueAsString(worklog.getProperties()),
           columns);
     } catch (JsonProcessingException e) {
-      throw new DASSdkException(e.getMessage());
+      throw new DASJiraUnexpectedError(e);
     }
 
     var updateAuthor =

--- a/das-jira-connector/src/main/java/com/rawlabs/das/jira/tables/definitions/DASJiraProjectRoleTable.java
+++ b/das-jira-connector/src/main/java/com/rawlabs/das/jira/tables/definitions/DASJiraProjectRoleTable.java
@@ -10,7 +10,6 @@ import com.rawlabs.das.jira.rest.platform.model.ProjectRole;
 import com.rawlabs.das.jira.rest.platform.model.RoleActor;
 import com.rawlabs.das.jira.tables.DASJiraTable;
 import com.rawlabs.das.sdk.DASExecuteResult;
-import com.rawlabs.das.sdk.DASSdkException;
 import com.rawlabs.protocol.das.v1.query.PathKey;
 import com.rawlabs.protocol.das.v1.query.Qual;
 import com.rawlabs.protocol.das.v1.query.SortKey;
@@ -58,7 +57,7 @@ public class DASJiraProjectRoleTable extends DASJiraTable {
     try {
       return toRow(projectRolesApi.createProjectRole(createUpdateRoleRequestBean(row)), List.of());
     } catch (ApiException e) {
-      throw new DASSdkException(e.getMessage());
+      throw makeSdkException(e);
     }
   }
 
@@ -70,7 +69,7 @@ public class DASJiraProjectRoleTable extends DASJiraTable {
               createUpdateRoleRequestBean(newValues)),
           List.of());
     } catch (ApiException e) {
-      throw new DASSdkException(e.getMessage());
+      throw makeSdkException(e);
     }
   }
 
@@ -78,7 +77,7 @@ public class DASJiraProjectRoleTable extends DASJiraTable {
     try {
       projectRolesApi.deleteProjectRole((Long) extractValueFactory.extractValue(rowId), null);
     } catch (ApiException e) {
-      throw new DASSdkException(e.getMessage());
+      throw makeSdkException(e);
     }
   }
 
@@ -88,7 +87,7 @@ public class DASJiraProjectRoleTable extends DASJiraTable {
       List<ProjectRole> result = projectRolesApi.getAllProjectRoles();
       return fromRowIterator(result.stream().map(r -> toRow(r, columns)).iterator());
     } catch (ApiException e) {
-      throw new DASSdkException(e.getMessage());
+      throw makeSdkException(e);
     }
   }
 

--- a/das-jira-connector/src/main/java/com/rawlabs/das/jira/tables/definitions/DASJiraProjectTable.java
+++ b/das-jira-connector/src/main/java/com/rawlabs/das/jira/tables/definitions/DASJiraProjectTable.java
@@ -5,6 +5,7 @@ import static com.rawlabs.das.jira.utils.factory.table.ColumnFactory.createColum
 import static com.rawlabs.das.jira.utils.factory.type.TypeFactory.*;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.rawlabs.das.jira.DASJiraUnexpectedError;
 import com.rawlabs.das.jira.rest.platform.ApiException;
 import com.rawlabs.das.jira.rest.platform.api.ProjectsApi;
 import com.rawlabs.das.jira.rest.platform.model.*;
@@ -12,7 +13,6 @@ import com.rawlabs.das.jira.tables.DASJiraTable;
 import com.rawlabs.das.jira.tables.results.DASJiraPage;
 import com.rawlabs.das.jira.tables.results.DASJiraPaginatedResult;
 import com.rawlabs.das.sdk.DASExecuteResult;
-import com.rawlabs.das.sdk.DASSdkException;
 import com.rawlabs.protocol.das.v1.query.PathKey;
 import com.rawlabs.protocol.das.v1.query.Qual;
 import com.rawlabs.protocol.das.v1.query.SortKey;
@@ -72,7 +72,7 @@ public class DASJiraProjectTable extends DASJiraTable {
       addToRow("self", rowBuilder, projectIdentifiers.getSelf(), List.of());
       return rowBuilder.build();
     } catch (ApiException e) {
-      throw new RuntimeException(e);
+      throw makeSdkException(e);
     }
   }
 
@@ -80,7 +80,7 @@ public class DASJiraProjectTable extends DASJiraTable {
     try {
       projectsApi.deleteProject((String) extractValueFactory.extractValue(rowId), true);
     } catch (ApiException e) {
-      throw new DASSdkException(e.getMessage());
+      throw makeSdkException(e);
     }
   }
 
@@ -104,7 +104,7 @@ public class DASJiraProjectTable extends DASJiraTable {
               (String) extractValueFactory.extractValue(rowId), updateProjectDetails, expand);
       return toRow(result, List.of());
     } catch (ApiException e) {
-      throw new DASSdkException(e.getMessage());
+      throw makeSdkException(e);
     }
   }
 
@@ -149,7 +149,7 @@ public class DASJiraProjectTable extends DASJiraTable {
                   null);
           return new DASJiraPage<>(searchResult.getValues(), searchResult.getTotal());
         } catch (ApiException e) {
-          throw new DASSdkException(e.getMessage(), e);
+          throw makeSdkException(e);
         }
       }
     };
@@ -191,7 +191,7 @@ public class DASJiraProjectTable extends DASJiraTable {
                   try {
                     return objectMapper.writeValueAsString(p);
                   } catch (JsonProcessingException e) {
-                    throw new DASSdkException(e.getMessage(), e);
+                    throw new DASJiraUnexpectedError(e);
                   }
                 })
             .orElse(null);

--- a/das-jira-connector/src/main/java/com/rawlabs/das/jira/tables/definitions/DASJiraSprintTable.java
+++ b/das-jira-connector/src/main/java/com/rawlabs/das/jira/tables/definitions/DASJiraSprintTable.java
@@ -14,7 +14,6 @@ import com.rawlabs.das.jira.tables.results.DASJiraPage;
 import com.rawlabs.das.jira.tables.results.DASJiraPaginatedResult;
 import com.rawlabs.das.jira.tables.results.DASJiraWithParentTableResult;
 import com.rawlabs.das.sdk.DASExecuteResult;
-import com.rawlabs.das.sdk.DASSdkException;
 import com.rawlabs.protocol.das.v1.query.Qual;
 import com.rawlabs.protocol.das.v1.query.SortKey;
 import com.rawlabs.protocol.das.v1.tables.ColumnDefinition;
@@ -60,7 +59,7 @@ public class DASJiraSprintTable extends DASJiraTable {
       Sprint sprint = sprintApi.createSprint(createSprintRequest);
       return toRow(sprint, sprint.getOriginBoardId(), List.of());
     } catch (ApiException e) {
-      throw new DASSdkException(e.getMessage());
+      throw makeSdkException(e);
     }
   }
 
@@ -81,7 +80,7 @@ public class DASJiraSprintTable extends DASJiraTable {
               (Long) extractValueFactory.extractValue(rowId), updateSprintRequest);
       return toRow(sprint, sprint.getOriginBoardId(), List.of());
     } catch (ApiException e) {
-      throw new DASSdkException(e.getMessage());
+      throw makeSdkException(e);
     }
   }
 
@@ -90,7 +89,7 @@ public class DASJiraSprintTable extends DASJiraTable {
     try {
       sprintApi.deleteSprint((Long) extractValueFactory.extractValue(rowId));
     } catch (ApiException e) {
-      throw new DASSdkException(e.getMessage());
+      throw makeSdkException(e);
     }
   }
 
@@ -115,7 +114,7 @@ public class DASJiraSprintTable extends DASJiraTable {
                   boardApi.getAllSprints(boardId, offset, withMaxResultOrLimit(limit), null);
               return new DASJiraPage<>(result.getValues(), result.getTotal());
             } catch (ApiException e) {
-              throw new DASSdkException(e.getResponseBody());
+              throw makeSdkException(e);
             }
           }
         };

--- a/das-jira-connector/src/main/java/com/rawlabs/das/jira/tables/definitions/DASJiraUserTable.java
+++ b/das-jira-connector/src/main/java/com/rawlabs/das/jira/tables/definitions/DASJiraUserTable.java
@@ -54,7 +54,7 @@ public class DASJiraUserTable extends DASJiraTable {
       User user = usersApi.createUser(newUserDetails);
       return toRow(user, List.of());
     } catch (ApiException e) {
-      throw new RuntimeException(e);
+      throw makeSdkException(e);
     }
   }
 
@@ -63,7 +63,7 @@ public class DASJiraUserTable extends DASJiraTable {
     try {
       usersApi.removeUser(extractValueFactory.extractValue(rowId).toString(), null, null);
     } catch (ApiException e) {
-      throw new RuntimeException(e);
+      throw makeSdkException(e);
     }
   }
 
@@ -74,7 +74,7 @@ public class DASJiraUserTable extends DASJiraTable {
       List<User> users = usersApi.getAllUsers(0, withMaxResultOrLimit(limit));
       return fromRowIterator(users.stream().map(u -> toRow(u, columns)).iterator());
     } catch (ApiException e) {
-      throw new RuntimeException(e);
+      throw makeSdkException(e);
     }
   }
 

--- a/das-jira-connector/src/main/java/com/rawlabs/das/jira/tables/definitions/DASJiraWorkflowTable.java
+++ b/das-jira-connector/src/main/java/com/rawlabs/das/jira/tables/definitions/DASJiraWorkflowTable.java
@@ -5,6 +5,7 @@ import static com.rawlabs.das.jira.utils.factory.table.ColumnFactory.createColum
 import static com.rawlabs.das.jira.utils.factory.type.TypeFactory.*;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.rawlabs.das.jira.DASJiraUnexpectedError;
 import com.rawlabs.das.jira.rest.platform.ApiException;
 import com.rawlabs.das.jira.rest.platform.api.WorkflowsApi;
 import com.rawlabs.das.jira.rest.platform.model.PageBeanWorkflow;
@@ -13,7 +14,6 @@ import com.rawlabs.das.jira.tables.DASJiraTable;
 import com.rawlabs.das.jira.tables.results.DASJiraPage;
 import com.rawlabs.das.jira.tables.results.DASJiraPaginatedResult;
 import com.rawlabs.das.sdk.DASExecuteResult;
-import com.rawlabs.das.sdk.DASSdkException;
 import com.rawlabs.protocol.das.v1.query.Qual;
 import com.rawlabs.protocol.das.v1.query.SortKey;
 import com.rawlabs.protocol.das.v1.tables.ColumnDefinition;
@@ -50,7 +50,7 @@ public class DASJiraWorkflowTable extends DASJiraTable {
     try {
       workflowsApi.deleteInactiveWorkflow(rowId.toString());
     } catch (ApiException e) {
-      throw new RuntimeException(e);
+      throw makeSdkException(e);
     }
   }
 
@@ -79,7 +79,7 @@ public class DASJiraWorkflowTable extends DASJiraTable {
                   null);
           return new DASJiraPage<>(result.getValues(), result.getTotal());
         } catch (ApiException e) {
-          throw new RuntimeException(e);
+          throw makeSdkException(e);
         }
       }
     };
@@ -103,7 +103,7 @@ public class DASJiraWorkflowTable extends DASJiraTable {
       addToRow(
           "statuses", rowBuilder, objectMapper.writeValueAsString(workflow.getStatuses()), columns);
     } catch (JsonProcessingException e) {
-      throw new DASSdkException(e.getMessage());
+      throw new DASJiraUnexpectedError(e);
     }
     addToRow("title", rowBuilder, workflow.getId().getName(), columns);
     return rowBuilder.build();

--- a/das-jira-connector/src/main/java/com/rawlabs/das/jira/tables/results/DASJiraWithParentTableResult.java
+++ b/das-jira-connector/src/main/java/com/rawlabs/das/jira/tables/results/DASJiraWithParentTableResult.java
@@ -1,8 +1,9 @@
 package com.rawlabs.das.jira.tables.results;
 
 import com.rawlabs.das.sdk.DASExecuteResult;
-import com.rawlabs.das.sdk.DASSdkException;
+import com.rawlabs.das.sdk.DASSdkInvalidArgumentException;
 import com.rawlabs.das.sdk.DASTable;
+import com.rawlabs.das.jira.DASJiraUnexpectedError;
 import com.rawlabs.protocol.das.v1.query.Qual;
 import com.rawlabs.protocol.das.v1.query.SortKey;
 import com.rawlabs.protocol.das.v1.tables.Row;
@@ -26,7 +27,7 @@ public abstract class DASJiraWithParentTableResult implements DASExecuteResult {
     try (DASExecuteResult parentResult = parentTable.execute(quals, columns, sortKeys, null)) {
       this.parentResult = parentResult;
     } catch (IOException e) {
-      throw new DASSdkException("Failed to execute parent table", e);
+      throw new DASJiraUnexpectedError(e);
     }
   }
 
@@ -50,7 +51,7 @@ public abstract class DASJiraWithParentTableResult implements DASExecuteResult {
         if (childResult.hasNext()) {
           return true;
         }
-      } catch (DASSdkException _) {
+      } catch (DASSdkInvalidArgumentException _) {
       }
     }
     return false;

--- a/das-jira-connector/src/test/java/com/rawlabs/das/jira/initializer/DASJiraInitializerTest.java
+++ b/das-jira-connector/src/test/java/com/rawlabs/das/jira/initializer/DASJiraInitializerTest.java
@@ -10,6 +10,8 @@ import com.rawlabs.das.jira.rest.platform.auth.HttpBasicAuth;
 import com.rawlabs.das.jira.rest.platform.auth.OAuth;
 import java.util.Map;
 import java.util.Objects;
+
+import com.rawlabs.das.sdk.DASSdkInvalidArgumentException;
 import okhttp3.Request;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -21,7 +23,7 @@ public class DASJiraInitializerTest {
   @DisplayName("Initialization fails when auth not provided")
   public void testJiraInitializer() {
     assertThrows(
-        IllegalArgumentException.class,
+        DASSdkInvalidArgumentException.class,
         () -> DASJiraInitializer.initializeSoftware(Map.of("base_url", "http://localhost:8080")));
   }
 

--- a/das-jira-connector/src/test/java/com/rawlabs/das/jira/tables/defnitions/DASJiraAdvancedSettingsTableTest.java
+++ b/das-jira-connector/src/test/java/com/rawlabs/das/jira/tables/defnitions/DASJiraAdvancedSettingsTableTest.java
@@ -11,7 +11,7 @@ import com.rawlabs.das.jira.rest.platform.api.JiraSettingsApi;
 import com.rawlabs.das.jira.rest.platform.model.ApplicationProperty;
 import com.rawlabs.das.jira.tables.definitions.DASJiraAdvancedSettingsTable;
 import com.rawlabs.das.sdk.DASExecuteResult;
-import com.rawlabs.das.sdk.DASSdkException;
+import com.rawlabs.das.sdk.DASSdkInvalidArgumentException;
 import com.rawlabs.das.jira.utils.factory.value.DefaultValueFactory;
 import com.rawlabs.das.jira.utils.factory.value.ValueFactory;
 import com.rawlabs.das.jira.utils.factory.value.ValueTypeTuple;
@@ -152,7 +152,7 @@ public class DASJiraAdvancedSettingsTableTest extends BaseMockTest {
   public void testGetAllAdvancedSettingsWithWithError() {
     ValueFactory valueFactory = new DefaultValueFactory();
     assertThrows(
-        DASSdkException.class,
+        DASSdkInvalidArgumentException.class,
         () -> {
           try (DASExecuteResult result =
               dasJiraAdvancedSettingsTable.execute(

--- a/das-jira-connector/src/test/java/com/rawlabs/das/jira/tables/defnitions/DASJiraBoardTableTest.java
+++ b/das-jira-connector/src/test/java/com/rawlabs/das/jira/tables/defnitions/DASJiraBoardTableTest.java
@@ -14,7 +14,7 @@ import com.rawlabs.das.jira.rest.software.model.GetAllBoards200ResponseValuesInn
 import com.rawlabs.das.jira.rest.software.model.GetConfiguration200Response;
 import com.rawlabs.das.jira.tables.definitions.DASJiraBoardTable;
 import com.rawlabs.das.sdk.DASExecuteResult;
-import com.rawlabs.das.sdk.DASSdkException;
+import com.rawlabs.das.sdk.DASSdkInvalidArgumentException;
 import com.rawlabs.das.jira.utils.factory.value.DefaultValueFactory;
 import com.rawlabs.das.jira.utils.factory.value.ValueFactory;
 import com.rawlabs.das.jira.utils.factory.value.ValueTypeTuple;
@@ -125,7 +125,7 @@ public class DASJiraBoardTableTest extends BaseMockTest {
   @DisplayName("Get with error")
   void testGetWithError() {
     assertThrows(
-        DASSdkException.class,
+        DASSdkInvalidArgumentException.class,
         () -> {
           try (DASExecuteResult result =
               dasJiraBoardTable.execute(


### PR DESCRIPTION
The JIRA API throws `ApiException`, which contains both a useful message and HTTP headers in a side field. Its implementation of `.getMessage` concatenates the message _and headers_. That's why the error message is so large.
```
ERROR:  Invalid argument
DETAIL:  {"code": "INVALID_ARGUMENT", "das_name": "localhost:50051",
"das_type": "jira", "das_url": "localhost:50051", "table_name": "jira_user",
"cause": "<_MultiThreadedRendezvous of RPC that terminated with:\n\tstatus =
StatusCode.INVALID_ARGUMENT\n\tdetails =
\"com.rawlabs.das.jira.rest.platform.ApiException: Message: \nHTTP response
code: 403\nHTTP response body:
{\"errorMessages\":[\"error.no-permission\"],\"errors\":{}}\nHTTP response
headers: {atl-request-id=[23638b90-e70d-4304-bc92-06c1be1fb35e],
atl-traceid=[23638b90e70d4304bc9206c1be1fb35e], cache-control=[no-store,
no-cache], content-type=[application/json;charset=UTF-8], date=[Wed, 26 Feb
2025 10:06:28 GMT], nel=[{\"failure_fraction\": 0.001, \"include_subdomains\":
true, \"max_age\": 600, \"report_to\": \"endpoint-1\"}],
report-to=[{\"endpoints\": [{\"url\":
\"https://dz8aopenkvv6s.cloudfront.net\"}], \"group\": \"endpoint-1\",
\"include_subdomains\": true, \"max_age\": 600}], server=[AtlassianEdge],
server-timing=[atl-edge;dur=105,atl-edge-internal;dur=19,atl-edge-upstream;dur=86,atl-edge-pop;desc=\"aws-us-west-2\"],
set-cookie=[atlassian.xsrf.token=f472ecf4334792d9776c8377a9c73315073a2da7_lout;
Path=/; SameSite=None; Secure], strict-transport-security=[max-age=63072000;
includeSubDomains; preload], timing-allow-origin=[*], via=[1.1
54ba4737103cb6263e414e602fbbe752.cloudfront.net (CloudFront)],
x-amz-cf-id=[x6ag0TnQ5mjeB1O-hfdLlT4_9vLVYHNvA5KLNlm19RNMG5S46bWuiQ==],
x-amz-cf-pop=[MRS52-P1], x-arequestid=[272d0ce7836dba60c20806bdcf3c585b],
x-cache=[Error from cloudfront], x-content-type-options=[nosniff],
x-seraph-loginreason=[AUTHENTICATED_FAILED], x-xss-protection=[1;
mode=block]}\"\n\tdebug_error_string = \"UNKNOWN:Error received from peer
{created_time:\"2025-02-26T11:06:28.188827+01:00\", grpc_status:3,
grpc_message:\"com.rawlabs.das.jira.rest.platform.ApiException: Message:
\\nHTTP response code: 403\\nHTTP response body:
{\\\"errorMessages\\\":[\\\"error.no-permission\\\"],\\\"errors\\\":{}}\\nHTTP
response headers: {atl-request-id=[23638b90-e70d-4304-bc92-06c1be1fb35e],
atl-traceid=[23638b90e70d4304bc9206c1be1fb35e], cache-control=[no-store,
no-cache], content-type=[application/json;charset=UTF-8], date=[Wed, 26 Feb
2025 10:06:28 GMT], nel=[{\\\"failure_fraction\\\": 0.001,
\\\"include_subdomains\\\": true, \\\"max_age\\\": 600, \\\"report_to\\\":
\\\"endpoint-1\\\"}], report-to=[{\\\"endpoints\\\": [{\\\"url\\\":
\\\"https://dz8aopenkvv6s.cloudfront.net\\\"}], \\\"group\\\":
\\\"endpoint-1\\\", \\\"include_subdomains\\\": true, \\\"max_age\\\": 600}],
server=[AtlassianEdge],
server-timing=[atl-edge;dur=105,atl-edge-internal;dur=19,atl-edge-upstream;dur=86,atl-edge-pop;desc=\\\"aws-us-west-2\\\"],
set-cookie=[atlassian.xsrf.token=f472ecf4334792d9776c8377a9c73315073a2da7_lout;
Path=/; SameSite=None; Secure], strict-transport-security=[max-age=63072000;
includeSubDomains; preload], timing-allow-origin=[*], via=[1.1
54ba4737103cb6263e414e602fbbe752.cloudfront.net (CloudFront)],
x-amz-cf-id=[x6ag0TnQ5mjeB1O-hfdLlT4_9vLVYHNvA5KLNlm19RNMG5S46bWuiQ==],
x-amz-cf-pop=[MRS52-P1], x-arequestid=[272d0ce7836dba60c20806bdcf3c585b],
x-cache=[Error from cloudfront], x-content-type-options=[nosniff],
x-seraph-loginreason=[AUTHENTICATED_FAILED], x-xss-protection=[1;
mode=block]}\"}\"\n>"}
```
With the patch, it's shorter since we only either propagate the response body only, or a generic message. This is fixed when catching `ApiException`, we throw an SDK one.

If triggering authentication errors by registering a DAS with wrong credentials, some endpoint succeed (those which don't require authentication), possibly returning fewer rows (e.g. only public items). But some fail. For example with 400, 401 or 403.

What the patch implements:

We never propagate HTTP headers and that kind of metadata. That shortens the message string. We only consider the message body, which I believe is the useful part of the error.

There's some handling of the HTTP code:
* 400: we propagate the error's body in a `DASSdkInvalidArgumentException`, because it should have useful detail. In the examples I triggered, the message is a json data structure. The API doesn't document the format of that JSON. I see it sometimes shown as an example but it's not specified.
* 401: I see it coming systematically with "Client must be authenticated to access this resource". The message is clean, but since the API doesn't document it, it's rewritten and wrapped in `DASSdkUnauthenticatedException`.
* 403: I saw it coming with a JSON body which structure isn't documented. Since we know the HTTP 403 code, the message is rewritten in our code and propagated with `DASSdkPermissionDeniedException`.
* others: we propagate the error's body.

JQL syntax/semantic errors are leading to 400, which is propagated as "invalid argument". In https://github.com/raw-labs/das-jira/pull/17 we fix JQL generation, but there are some errors we can hardly avoid, that lead to 400. For example this query filters on a invalid `status_category`, which means it doesn't match any row.
```sql
SELECT *
FROM jira.jira_issue
WHERE status_category = 'tralala' -- this is a silly category
```
This leads to JQL: `statusCategory = "tralala"` which fails with 400.
```
ERROR:  {"errorMessages":["The value 'tralala' does not exist for the field 
'statusCategory'."],"warningMessages":[]}                                                                          
DETAIL:  {"code": "INVALID_ARGUMENT", "message": "{\"errorMessages\":[\"The
value 'tralala' does not exist for the field
'statusCategory'.\"],\"warningMessages\":[]}", "das_name": "localhost:50051",
"das_type": "jira", "das_url": "localhost:50051", "table_name": "jira_issue",
"cause": "<_MultiThreadedRendezvous of RPC that terminated with:\n\tstatus =
StatusCode.INVALID_ARGUMENT\n\tdetails = \"{\"errorMessages\":[\"The value
'tralala' does not exist for the field
'statusCategory'.\"],\"warningMessages\":[]}\"\n\tdebug_error_string =
\"UNKNOWN:Error received from peer
{grpc_message:\"{\\\"errorMessages\\\":[\\\"The value \\'tralala\\' does not
exist for the field \\'statusCategory\\'.\\\"],\\\"warningMessages\\\":[]}\",
grpc_status:3, created_time:\"2025-02-28T15:18:26.003452+01:00\"}\"\n>"}
```
> [!NOTE]
>  The JSON structure I see is systematically an object with an `errorMessages` key that is a list of error strings.
> I haven't implemented an attempt to extract and concatenate those. Maybe we could do that?
Legitimate queries leading to bad JQL because of a bug also hit 400 and are also propagated to users (while it's technically a bug in the DAS).

