### PR TITLE
chore(update): bump netty-handler and json deps

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,4 +65,20 @@
         <joda-time-version>2.13.0</joda-time-version>
     </properties>
 
+    <dependencyManagement>
+        <dependencies>
+            <!-- Security vulnerability overrides -->
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-handler</artifactId>
+                <version>4.1.118.Final</version>
+            </dependency>
+            <dependency>
+                <groupId>org.json</groupId>
+                <artifactId>json</artifactId>
+                <version>20231013</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
 </project>


### PR DESCRIPTION
for

- CVE-2022-45688
- CVE-2023-5072
- CVE-2025-24970
