### PR TITLE
Fail at registration

### DIFF
--- a/das-jira-connector/src/main/java/com/rawlabs/das/jira/DASJira.java
+++ b/das-jira-connector/src/main/java/com/rawlabs/das/jira/DASJira.java
@@ -1,10 +1,12 @@
 package com.rawlabs.das.jira;
 
+import static com.rawlabs.das.jira.utils.ExceptionHandling.makeSdkException;
+
 import com.rawlabs.das.jira.initializer.DASJiraInitializer;
+import com.rawlabs.das.jira.rest.platform.ApiException;
+import com.rawlabs.das.jira.rest.platform.api.MyselfApi;
 import com.rawlabs.das.jira.tables.DASJiraTableManager;
-import com.rawlabs.das.sdk.DASFunction;
-import com.rawlabs.das.sdk.DASSdk;
-import com.rawlabs.das.sdk.DASTable;
+import com.rawlabs.das.sdk.*;
 import com.rawlabs.protocol.das.v1.functions.FunctionDefinition;
 import com.rawlabs.protocol.das.v1.tables.TableDefinition;
 import java.util.List;
@@ -13,14 +15,27 @@ import java.util.Optional;
 
 public class DASJira implements DASSdk {
 
-  private final Map<String, String> options;
   private final DASJiraTableManager tableManager;
 
   protected DASJira(Map<String, String> options) {
     var apiClientPlatform = DASJiraInitializer.initializePlatform(options);
     var apiClientSoftware = DASJiraInitializer.initializeSoftware(options);
+    checkAuthentication(apiClientPlatform);
     tableManager = new DASJiraTableManager(options, apiClientPlatform, apiClientSoftware);
-    this.options = options;
+  }
+
+  private void checkAuthentication(com.rawlabs.das.jira.rest.platform.ApiClient apiClientPlatform) {
+    MyselfApi api = new MyselfApi(apiClientPlatform);
+    try {
+      api.getCurrentUser(null);
+    } catch (ApiException e) {
+      throw makeSdkException(e);
+    } catch (IllegalArgumentException e) {
+      // That happens if the URL is not valid.
+      throw new DASSdkInvalidArgumentException(e.getMessage(), e);
+    } catch (Throwable t) {
+      throw new RuntimeException(t);
+    }
   }
 
   public List<TableDefinition> getTableDefinitions() {

--- a/das-jira-connector/src/main/java/com/rawlabs/das/jira/tables/DASJiraTable.java
+++ b/das-jira-connector/src/main/java/com/rawlabs/das/jira/tables/DASJiraTable.java
@@ -125,42 +125,4 @@ public abstract class DASJiraTable implements DASTable {
     return OffsetDateTime.parse(dateString, formatter);
   }
 
-  // A helper to fallback to a default message if ever the body would be empty or null.
-  private static String mkMessage(String msg) {
-    if (msg == null || msg.trim().isEmpty()) {
-      return "Unknown JIRA API error";
-    }
-    return msg;
-  }
-
-  /**
-   * Helper method to create a DASSdk RuntimeException from an ApiException.
-   *
-   * <p>When the SDK exposes more exceptions (e.g. authentication errors), this method can
-   * investigate the ApiException and create the appropriate SDK exception.
-   *
-   * @param e the ApiException to convert
-   * @return the RuntimeException to throw
-   */
-  protected RuntimeException makeSdkException(ApiException e) {
-    return switch (e.getCode()) {
-      case 400 -> new DASSdkInvalidArgumentException(mkMessage(e.getResponseBody()), e);
-      case 401 -> new DASSdkUnauthenticatedException("unauthorized", e);
-      case 403 -> new DASSdkPermissionDeniedException("permission denied", e);
-      default ->
-          // For now, just create a generic SDK exception with the body of the ApiException
-          new DASSdkInvalidArgumentException(mkMessage(e.getResponseBody()), e);
-    };
-  }
-
-  protected RuntimeException makeSdkException(com.rawlabs.das.jira.rest.software.ApiException e) {
-    return switch (e.getCode()) {
-      case 400 -> new DASSdkInvalidArgumentException(mkMessage(e.getResponseBody()), e);
-      case 401 -> new DASSdkUnauthenticatedException("unauthorized", e);
-      case 403 -> new DASSdkPermissionDeniedException("permission denied", e);
-      default ->
-          // For now, just create a generic SDK exception with the body of the ApiException
-          new DASSdkInvalidArgumentException(mkMessage(e.getResponseBody()), e);
-    };
-  }
 }

--- a/das-jira-connector/src/main/java/com/rawlabs/das/jira/tables/definitions/DASJiraAdvancedSettingsTable.java
+++ b/das-jira-connector/src/main/java/com/rawlabs/das/jira/tables/definitions/DASJiraAdvancedSettingsTable.java
@@ -1,5 +1,6 @@
 package com.rawlabs.das.jira.tables.definitions;
 
+import static com.rawlabs.das.jira.utils.ExceptionHandling.makeSdkException;
 import static com.rawlabs.das.jira.utils.factory.qual.ExtractQualFactory.extractEqDistinct;
 import static com.rawlabs.das.jira.utils.factory.table.ColumnFactory.createColumn;
 import static com.rawlabs.das.jira.utils.factory.type.TypeFactory.*;

--- a/das-jira-connector/src/main/java/com/rawlabs/das/jira/tables/definitions/DASJiraBacklogIssueTable.java
+++ b/das-jira-connector/src/main/java/com/rawlabs/das/jira/tables/definitions/DASJiraBacklogIssueTable.java
@@ -1,5 +1,6 @@
 package com.rawlabs.das.jira.tables.definitions;
 
+import static com.rawlabs.das.jira.utils.ExceptionHandling.makeSdkException;
 import static com.rawlabs.das.jira.utils.factory.table.ColumnFactory.createColumn;
 import static com.rawlabs.das.jira.utils.factory.type.TypeFactory.*;
 

--- a/das-jira-connector/src/main/java/com/rawlabs/das/jira/tables/definitions/DASJiraBoardTable.java
+++ b/das-jira-connector/src/main/java/com/rawlabs/das/jira/tables/definitions/DASJiraBoardTable.java
@@ -1,5 +1,6 @@
 package com.rawlabs.das.jira.tables.definitions;
 
+import static com.rawlabs.das.jira.utils.ExceptionHandling.makeSdkException;
 import static com.rawlabs.das.jira.utils.factory.qual.ExtractQualFactory.extractEqDistinct;
 import static com.rawlabs.das.jira.utils.factory.table.ColumnFactory.createColumn;
 import static com.rawlabs.das.jira.utils.factory.type.TypeFactory.*;

--- a/das-jira-connector/src/main/java/com/rawlabs/das/jira/tables/definitions/DASJiraComponentTable.java
+++ b/das-jira-connector/src/main/java/com/rawlabs/das/jira/tables/definitions/DASJiraComponentTable.java
@@ -1,5 +1,6 @@
 package com.rawlabs.das.jira.tables.definitions;
 
+import static com.rawlabs.das.jira.utils.ExceptionHandling.makeSdkException;
 import static com.rawlabs.das.jira.utils.factory.table.ColumnFactory.createColumn;
 import static com.rawlabs.das.jira.utils.factory.type.TypeFactory.*;
 import static com.rawlabs.das.jira.utils.factory.type.TypeFactory.createStringType;

--- a/das-jira-connector/src/main/java/com/rawlabs/das/jira/tables/definitions/DASJiraDashboardTable.java
+++ b/das-jira-connector/src/main/java/com/rawlabs/das/jira/tables/definitions/DASJiraDashboardTable.java
@@ -1,5 +1,6 @@
 package com.rawlabs.das.jira.tables.definitions;
 
+import static com.rawlabs.das.jira.utils.ExceptionHandling.makeSdkException;
 import static com.rawlabs.das.jira.utils.factory.table.ColumnFactory.createColumn;
 import static com.rawlabs.das.jira.utils.factory.type.TypeFactory.*;
 

--- a/das-jira-connector/src/main/java/com/rawlabs/das/jira/tables/definitions/DASJiraEpicTable.java
+++ b/das-jira-connector/src/main/java/com/rawlabs/das/jira/tables/definitions/DASJiraEpicTable.java
@@ -1,5 +1,6 @@
 package com.rawlabs.das.jira.tables.definitions;
 
+import static com.rawlabs.das.jira.utils.ExceptionHandling.makeSdkException;
 import static com.rawlabs.das.jira.utils.factory.table.ColumnFactory.createColumn;
 import static com.rawlabs.das.jira.utils.factory.type.TypeFactory.*;
 

--- a/das-jira-connector/src/main/java/com/rawlabs/das/jira/tables/definitions/DASJiraGlobalSettingTable.java
+++ b/das-jira-connector/src/main/java/com/rawlabs/das/jira/tables/definitions/DASJiraGlobalSettingTable.java
@@ -1,5 +1,6 @@
 package com.rawlabs.das.jira.tables.definitions;
 
+import static com.rawlabs.das.jira.utils.ExceptionHandling.makeSdkException;
 import static com.rawlabs.das.jira.utils.factory.table.ColumnFactory.createColumn;
 import static com.rawlabs.das.jira.utils.factory.type.TypeFactory.*;
 

--- a/das-jira-connector/src/main/java/com/rawlabs/das/jira/tables/definitions/DASJiraGroupTable.java
+++ b/das-jira-connector/src/main/java/com/rawlabs/das/jira/tables/definitions/DASJiraGroupTable.java
@@ -1,5 +1,6 @@
 package com.rawlabs.das.jira.tables.definitions;
 
+import static com.rawlabs.das.jira.utils.ExceptionHandling.makeSdkException;
 import static com.rawlabs.das.jira.utils.factory.table.ColumnFactory.createColumn;
 import static com.rawlabs.das.jira.utils.factory.type.TypeFactory.*;
 

--- a/das-jira-connector/src/main/java/com/rawlabs/das/jira/tables/definitions/DASJiraIssueCommentTable.java
+++ b/das-jira-connector/src/main/java/com/rawlabs/das/jira/tables/definitions/DASJiraIssueCommentTable.java
@@ -1,5 +1,6 @@
 package com.rawlabs.das.jira.tables.definitions;
 
+import static com.rawlabs.das.jira.utils.ExceptionHandling.makeSdkException;
 import static com.rawlabs.das.jira.utils.factory.table.ColumnFactory.createColumn;
 import static com.rawlabs.das.jira.utils.factory.type.TypeFactory.*;
 

--- a/das-jira-connector/src/main/java/com/rawlabs/das/jira/tables/definitions/DASJiraIssueTable.java
+++ b/das-jira-connector/src/main/java/com/rawlabs/das/jira/tables/definitions/DASJiraIssueTable.java
@@ -1,5 +1,6 @@
 package com.rawlabs.das.jira.tables.definitions;
 
+import static com.rawlabs.das.jira.utils.ExceptionHandling.makeSdkException;
 import static com.rawlabs.das.jira.utils.factory.table.ColumnFactory.createColumn;
 import static com.rawlabs.das.jira.utils.factory.type.TypeFactory.*;
 

--- a/das-jira-connector/src/main/java/com/rawlabs/das/jira/tables/definitions/DASJiraIssueTypeTable.java
+++ b/das-jira-connector/src/main/java/com/rawlabs/das/jira/tables/definitions/DASJiraIssueTypeTable.java
@@ -1,5 +1,6 @@
 package com.rawlabs.das.jira.tables.definitions;
 
+import static com.rawlabs.das.jira.utils.ExceptionHandling.makeSdkException;
 import static com.rawlabs.das.jira.utils.factory.table.ColumnFactory.createColumn;
 import static com.rawlabs.das.jira.utils.factory.type.TypeFactory.*;
 

--- a/das-jira-connector/src/main/java/com/rawlabs/das/jira/tables/definitions/DASJiraIssueWorklogTable.java
+++ b/das-jira-connector/src/main/java/com/rawlabs/das/jira/tables/definitions/DASJiraIssueWorklogTable.java
@@ -1,5 +1,6 @@
 package com.rawlabs.das.jira.tables.definitions;
 
+import static com.rawlabs.das.jira.utils.ExceptionHandling.makeSdkException;
 import static com.rawlabs.das.jira.utils.factory.table.ColumnFactory.createColumn;
 import static com.rawlabs.das.jira.utils.factory.type.TypeFactory.*;
 

--- a/das-jira-connector/src/main/java/com/rawlabs/das/jira/tables/definitions/DASJiraProjectRoleTable.java
+++ b/das-jira-connector/src/main/java/com/rawlabs/das/jira/tables/definitions/DASJiraProjectRoleTable.java
@@ -1,5 +1,6 @@
 package com.rawlabs.das.jira.tables.definitions;
 
+import static com.rawlabs.das.jira.utils.ExceptionHandling.makeSdkException;
 import static com.rawlabs.das.jira.utils.factory.table.ColumnFactory.createColumn;
 import static com.rawlabs.das.jira.utils.factory.type.TypeFactory.*;
 

--- a/das-jira-connector/src/main/java/com/rawlabs/das/jira/tables/definitions/DASJiraProjectTable.java
+++ b/das-jira-connector/src/main/java/com/rawlabs/das/jira/tables/definitions/DASJiraProjectTable.java
@@ -1,5 +1,6 @@
 package com.rawlabs.das.jira.tables.definitions;
 
+import static com.rawlabs.das.jira.utils.ExceptionHandling.makeSdkException;
 import static com.rawlabs.das.jira.utils.factory.qual.ExtractQualFactory.extractEqDistinct;
 import static com.rawlabs.das.jira.utils.factory.table.ColumnFactory.createColumn;
 import static com.rawlabs.das.jira.utils.factory.type.TypeFactory.*;

--- a/das-jira-connector/src/main/java/com/rawlabs/das/jira/tables/definitions/DASJiraSprintTable.java
+++ b/das-jira-connector/src/main/java/com/rawlabs/das/jira/tables/definitions/DASJiraSprintTable.java
@@ -1,5 +1,6 @@
 package com.rawlabs.das.jira.tables.definitions;
 
+import static com.rawlabs.das.jira.utils.ExceptionHandling.makeSdkException;
 import static com.rawlabs.das.jira.utils.factory.table.ColumnFactory.createColumn;
 import static com.rawlabs.das.jira.utils.factory.type.TypeFactory.*;
 

--- a/das-jira-connector/src/main/java/com/rawlabs/das/jira/tables/definitions/DASJiraUserTable.java
+++ b/das-jira-connector/src/main/java/com/rawlabs/das/jira/tables/definitions/DASJiraUserTable.java
@@ -1,5 +1,6 @@
 package com.rawlabs.das.jira.tables.definitions;
 
+import static com.rawlabs.das.jira.utils.ExceptionHandling.makeSdkException;
 import static com.rawlabs.das.jira.utils.factory.table.ColumnFactory.createColumn;
 import static com.rawlabs.das.jira.utils.factory.type.TypeFactory.*;
 

--- a/das-jira-connector/src/main/java/com/rawlabs/das/jira/tables/definitions/DASJiraWorkflowTable.java
+++ b/das-jira-connector/src/main/java/com/rawlabs/das/jira/tables/definitions/DASJiraWorkflowTable.java
@@ -1,5 +1,6 @@
 package com.rawlabs.das.jira.tables.definitions;
 
+import static com.rawlabs.das.jira.utils.ExceptionHandling.makeSdkException;
 import static com.rawlabs.das.jira.utils.factory.qual.ExtractQualFactory.extractEqDistinct;
 import static com.rawlabs.das.jira.utils.factory.table.ColumnFactory.createColumn;
 import static com.rawlabs.das.jira.utils.factory.type.TypeFactory.*;

--- a/das-jira-connector/src/main/java/com/rawlabs/das/jira/utils/ExceptionHandling.java
+++ b/das-jira-connector/src/main/java/com/rawlabs/das/jira/utils/ExceptionHandling.java
@@ -6,64 +6,65 @@ import com.rawlabs.das.sdk.DASSdkUnauthenticatedException;
 
 public final class ExceptionHandling {
 
-    private ExceptionHandling() {
-        // Prevent instantiation
-    }
+  private ExceptionHandling() {
+    // Prevent instantiation
+  }
 
-    /**
-     * Helper method to create a DASSdk RuntimeException from an ApiException.
-     *
-     * <p>When the SDK exposes more exceptions (e.g. authentication errors), this method can
-     * investigate the ApiException and create the appropriate SDK exception.
-     *
-     * @param e the ApiException to convert
-     * @return the RuntimeException to throw
-     */
-    public static RuntimeException makeSdkException(com.rawlabs.das.jira.rest.platform.ApiException e) {
-        if (e.getCode() == 0 && e.getCause() instanceof java.net.UnknownHostException) {
-            // That happens if the host is not found.
-            return new DASSdkInvalidArgumentException(e.getCause().getMessage(), e);
-        }
-        return switch (e.getCode()) {
-            case 400 -> new DASSdkInvalidArgumentException(mkMessage(e.getResponseBody()), e);
-            case 401 -> new DASSdkUnauthenticatedException("unauthorized", e);
-            case 403 -> new DASSdkPermissionDeniedException("permission denied", e);
-            default ->
-                // For now, just create a generic SDK exception with the body of the ApiException
-                    new DASSdkInvalidArgumentException(mkMessage(e.getResponseBody()), e);
-        };
+  /**
+   * Helper method to create a DASSdk RuntimeException from an ApiException.
+   *
+   * <p>When the SDK exposes more exceptions (e.g. authentication errors), this method can
+   * investigate the ApiException and create the appropriate SDK exception.
+   *
+   * @param e the ApiException to convert
+   * @return the RuntimeException to throw
+   */
+  public static RuntimeException makeSdkException(
+      com.rawlabs.das.jira.rest.platform.ApiException e) {
+    if (e.getCode() == 0 && e.getCause() instanceof java.net.UnknownHostException) {
+      // That happens if the host is not found.
+      return new DASSdkInvalidArgumentException(e.getCause().getMessage(), e);
     }
+    return switch (e.getCode()) {
+      case 400 -> new DASSdkInvalidArgumentException(mkMessage(e.getResponseBody()), e);
+      case 401 -> new DASSdkUnauthenticatedException("unauthorized", e);
+      case 403 -> new DASSdkPermissionDeniedException("permission denied", e);
+      default ->
+          // For now, just create a generic SDK exception with the body of the ApiException
+          new DASSdkInvalidArgumentException(mkMessage(e.getResponseBody()), e);
+    };
+  }
 
-    /**
-     * Helper method to create a DASSdk RuntimeException from an ApiException.
-     *
-     * <p>When the SDK exposes more exceptions (e.g. authentication errors), this method can
-     * investigate the ApiException and create the appropriate SDK exception.
-     *
-     * @param e the ApiException to convert
-     * @return the RuntimeException to throw
-     */
-    public static RuntimeException makeSdkException(com.rawlabs.das.jira.rest.software.ApiException e) {
-        if (e.getCode() == 0 && e.getCause() instanceof java.net.UnknownHostException) {
-            // That happens if the host is not found.
-            return new DASSdkInvalidArgumentException(e.getCause().getMessage(), e);
-        }
-        return switch (e.getCode()) {
-            case 400 -> new DASSdkInvalidArgumentException(mkMessage(e.getResponseBody()), e);
-            case 401 -> new DASSdkUnauthenticatedException("unauthorized", e);
-            case 403 -> new DASSdkPermissionDeniedException("permission denied", e);
-            default ->
-                // For now, just create a generic SDK exception with the body of the ApiException
-                    new DASSdkInvalidArgumentException(mkMessage(e.getResponseBody()), e);
-        };
+  /**
+   * Helper method to create a DASSdk RuntimeException from an ApiException.
+   *
+   * <p>When the SDK exposes more exceptions (e.g. authentication errors), this method can
+   * investigate the ApiException and create the appropriate SDK exception.
+   *
+   * @param e the ApiException to convert
+   * @return the RuntimeException to throw
+   */
+  public static RuntimeException makeSdkException(
+      com.rawlabs.das.jira.rest.software.ApiException e) {
+    if (e.getCode() == 0 && e.getCause() instanceof java.net.UnknownHostException) {
+      // That happens if the host is not found.
+      return new DASSdkInvalidArgumentException(e.getCause().getMessage(), e);
     }
+    return switch (e.getCode()) {
+      case 400 -> new DASSdkInvalidArgumentException(mkMessage(e.getResponseBody()), e);
+      case 401 -> new DASSdkUnauthenticatedException("unauthorized", e);
+      case 403 -> new DASSdkPermissionDeniedException("permission denied", e);
+      default ->
+          // For now, just create a generic SDK exception with the body of the ApiException
+          new DASSdkInvalidArgumentException(mkMessage(e.getResponseBody()), e);
+    };
+  }
 
-    // A helper to fallback to a default message if ever the body would be empty or null.
-    private static String mkMessage(String msg) {
-        if (msg == null || msg.trim().isEmpty()) {
-            return "Unknown JIRA API error";
-        }
-        return msg;
+  // A helper to fallback to a default message if ever the body would be empty or null.
+  private static String mkMessage(String msg) {
+    if (msg == null || msg.trim().isEmpty()) {
+      return "Unknown JIRA API error";
     }
-
+    return msg;
+  }
 }

--- a/das-jira-connector/src/main/java/com/rawlabs/das/jira/utils/ExceptionHandling.java
+++ b/das-jira-connector/src/main/java/com/rawlabs/das/jira/utils/ExceptionHandling.java
@@ -1,0 +1,69 @@
+package com.rawlabs.das.jira.utils;
+
+import com.rawlabs.das.sdk.DASSdkInvalidArgumentException;
+import com.rawlabs.das.sdk.DASSdkPermissionDeniedException;
+import com.rawlabs.das.sdk.DASSdkUnauthenticatedException;
+
+public final class ExceptionHandling {
+
+    private ExceptionHandling() {
+        // Prevent instantiation
+    }
+
+    /**
+     * Helper method to create a DASSdk RuntimeException from an ApiException.
+     *
+     * <p>When the SDK exposes more exceptions (e.g. authentication errors), this method can
+     * investigate the ApiException and create the appropriate SDK exception.
+     *
+     * @param e the ApiException to convert
+     * @return the RuntimeException to throw
+     */
+    public static RuntimeException makeSdkException(com.rawlabs.das.jira.rest.platform.ApiException e) {
+        if (e.getCode() == 0 && e.getCause() instanceof java.net.UnknownHostException) {
+            // That happens if the host is not found.
+            return new DASSdkInvalidArgumentException(e.getCause().getMessage(), e);
+        }
+        return switch (e.getCode()) {
+            case 400 -> new DASSdkInvalidArgumentException(mkMessage(e.getResponseBody()), e);
+            case 401 -> new DASSdkUnauthenticatedException("unauthorized", e);
+            case 403 -> new DASSdkPermissionDeniedException("permission denied", e);
+            default ->
+                // For now, just create a generic SDK exception with the body of the ApiException
+                    new DASSdkInvalidArgumentException(mkMessage(e.getResponseBody()), e);
+        };
+    }
+
+    /**
+     * Helper method to create a DASSdk RuntimeException from an ApiException.
+     *
+     * <p>When the SDK exposes more exceptions (e.g. authentication errors), this method can
+     * investigate the ApiException and create the appropriate SDK exception.
+     *
+     * @param e the ApiException to convert
+     * @return the RuntimeException to throw
+     */
+    public static RuntimeException makeSdkException(com.rawlabs.das.jira.rest.software.ApiException e) {
+        if (e.getCode() == 0 && e.getCause() instanceof java.net.UnknownHostException) {
+            // That happens if the host is not found.
+            return new DASSdkInvalidArgumentException(e.getCause().getMessage(), e);
+        }
+        return switch (e.getCode()) {
+            case 400 -> new DASSdkInvalidArgumentException(mkMessage(e.getResponseBody()), e);
+            case 401 -> new DASSdkUnauthenticatedException("unauthorized", e);
+            case 403 -> new DASSdkPermissionDeniedException("permission denied", e);
+            default ->
+                // For now, just create a generic SDK exception with the body of the ApiException
+                    new DASSdkInvalidArgumentException(mkMessage(e.getResponseBody()), e);
+        };
+    }
+
+    // A helper to fallback to a default message if ever the body would be empty or null.
+    private static String mkMessage(String msg) {
+        if (msg == null || msg.trim().isEmpty()) {
+            return "Unknown JIRA API error";
+        }
+        return msg;
+    }
+
+}

--- a/das-jira-connector/src/test/java/com/rawlabs/das/jira/DASJiraTest.java
+++ b/das-jira-connector/src/test/java/com/rawlabs/das/jira/DASJiraTest.java
@@ -43,6 +43,6 @@ public class DASJiraTest {
                         "personal_access_token",
                         "pat"),
                     null));
-    assertTrue(exception.getMessage().contains("this-doesn-t-exist.com: nodename nor servname provided, or not known"), exception.getMessage());
+    assertTrue(exception.getMessage().contains("this-doesn-t-exist.com"), exception.getMessage());
   }
 }

--- a/das-jira-connector/src/test/java/com/rawlabs/das/jira/DASJiraTest.java
+++ b/das-jira-connector/src/test/java/com/rawlabs/das/jira/DASJiraTest.java
@@ -2,11 +2,8 @@ package com.rawlabs.das.jira;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import com.rawlabs.das.jira.tables.definitions.DASJiraAdvancedSettingsTable;
-import com.rawlabs.das.sdk.DASSdk;
-import com.rawlabs.das.sdk.DASTable;
+import com.rawlabs.das.sdk.DASSdkInvalidArgumentException;
 import java.util.Map;
-import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -18,13 +15,34 @@ public class DASJiraTest {
     DASJiraBuilder dasJiraBuilder = new DASJiraBuilder();
     assertNotNull(dasJiraBuilder);
     assertEquals("jira", dasJiraBuilder.getDasType());
-    DASSdk dasJira =
-        dasJiraBuilder.build(Map.of("base_url", "test_url", "personal_access_token", "pat"), null);
-    assertNotNull(dasJira);
-    assertInstanceOf(DASJira.class, dasJira);
-    int tableDefinitionsCount = dasJira.getTableDefinitions().size();
-    assertNotEquals(0, tableDefinitionsCount);
-    Optional<DASTable> tablesCount = dasJira.getTable(DASJiraAdvancedSettingsTable.TABLE_NAME);
-    assertTrue(tablesCount.isPresent());
+  }
+
+  @Test
+  public void testMalformedUrl() {
+    DASJiraBuilder dasJiraBuilder = new DASJiraBuilder();
+    DASSdkInvalidArgumentException exception =
+        assertThrows(
+            DASSdkInvalidArgumentException.class,
+            () ->
+                dasJiraBuilder.build(
+                    Map.of("base_url", "tralala", "personal_access_token", "pat"), null));
+    assertTrue(exception.getMessage().contains("no scheme was found"), exception.getMessage());
+  }
+
+  @Test
+  public void testUnknownHost() {
+    DASJiraBuilder dasJiraBuilder = new DASJiraBuilder();
+    DASSdkInvalidArgumentException exception =
+        assertThrows(
+            DASSdkInvalidArgumentException.class,
+            () ->
+                dasJiraBuilder.build(
+                    Map.of(
+                        "base_url",
+                        "https://this-doesn-t-exist.com",
+                        "personal_access_token",
+                        "pat"),
+                    null));
+    assertTrue(exception.getMessage().contains("this-doesn-t-exist.com: nodename nor servname provided, or not known"), exception.getMessage());
   }
 }


### PR DESCRIPTION
By verifying the user’s identity during registration, we can uncover authentication or argument issues early. In the future, we may need to retrieve user information at startup, for example to detect the user’s timezone for timestamp support, and any errors would naturally surface at that point.

I’ve refactored the error handling into a helper class so that it can be reused not only for table operations but also for server-side code. Additionally, I added extra logic to handle two scenarios observed during testing: one for malformed URLs and one for URLs that point to a non-existent host.